### PR TITLE
feat: 加入自动更新等功能

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,43 +1,51 @@
 # bilive_client
 
+[![Node.js](https://img.shields.io/badge/Node.js-v10.0%2B-green.svg)](https://nodejs.org)
+[![Commitizen friendly](https://img.shields.io/badge/Commitizen-Friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
+![GitHub repo size](https://img.shields.io/github/repo-size/Vector000/bilive_client.svg)
+[![MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/Vector000/bilive_client/blob/2.1.0-beta/LICENSE)
+
 * 这是一个次分支，感谢所有对[主分支](https://github.com/lzghzr/bilive_client)做出贡献的人及其他同类开源软件的开发者
 * 有兴趣支持原作者的，请朝这里打钱=>[给lzghzr打钱](https://github.com/lzghzr/bilive_client/wiki)
 * 有兴趣向我投喂的，请朝这里打钱=>[请给我钱](https://github.com/Vector000/Something_Serious/blob/master/pics/mm_reward_qrcode.png)
-
-
 * 感谢大佬的推荐！趴 _(:3」∠)_
 
-## 自行编译
+## 使用方法
 
-* 第一次使用
+* 2.1.0
+
 1. 安装[Node.js](https://nodejs.org/)
-2. 安装[git](https://git-scm.com/downloads)
+2. 安装[Git](https://git-scm.com/downloads)
 3. 选择并定位到想要安装的目录
 4. `git clone https://github.com/Vector000/bilive_client.git`
 5. `cd bilive_client`
-6. `npm install`
-7. `npm run build`
-8. `npm start`
+6. `npm i` 或 `npm install`
+7. `npm start`
 
-* 版本更新
+2.1.0具有自动更新功能 启动时自动检查/每天检查两次
+
+* 版本更新(手动从旧版本更新)
+  
 1. 定位到目录
 2. `git pull`
-3. `npm install`
-4. `npm run clean`
-5. `npm run build`
-6. `npm start`
+3. `npm i` 或 `npm install`
+4. `npm start`
+
 更新之后可能会出现不兼容的情况，可删去`options/options.json`后重新进行设置
 
 可使用网页设置：[点此进行设置](http://vector000.coding.me/bilive_setting/)\
 推荐使用`doc/index.html`进行本地设置
 
 ### 设置相关
+
 服务器挂机用户可通过防火墙设置来开启远程设置，但由此产生的信息泄露及其他风险请自行承担
 
 ## 使用releases
+
 不存在的，不存在的，永远也不会发release的
 
 ## Features
+
 * 定时查询挂机效益和用户各类信息，支持统计信息sc微信推送
 * 支持根据佩戴勋章的每日亲密度自动赠送礼物
 * 添加entry_action以部分规避封禁（玄学，没什么卵用）
@@ -47,6 +55,8 @@
 * 支持连接云监听转发服务器
 * 全局统计，可查看当日挂机成果
 * 节奏风暴多次发包以提高中奖率(设置过高风险自负)
+* 自动更新，免去频繁设置命令行的麻烦
 
 ## TO-DO
+
 * 咕咕咕咕咕咕咕

--- a/app.ts
+++ b/app.ts
@@ -1,3 +1,0 @@
-const BiLive = require(__dirname + '/bilive/index').default
-const bilive = new BiLive()
-bilive.Start()

--- a/bilive/@types/bilive.d.ts
+++ b/bilive/@types/bilive.d.ts
@@ -33,6 +33,7 @@ interface advConfig {
   [index: string]: boolean | number | string | number[]
   defaultUserID: number
   serverURL: string
+  bakServerURL: string
   eventRooms: number[]
 }
 interface userCollection {
@@ -487,7 +488,7 @@ interface IPlugin extends EPlugin {
   author: string
   loaded: boolean
   load?({ defaultOptions, whiteList }: { defaultOptions: options, whiteList: Set<string> }): Promise<void>
-  start?({ options, users }: { options: options, users: Map<string, User> }): Promise<void>
+  start?({ options, users }: { options: options, users: Map<string, User> }, newUser: boolean): Promise<void>
   loop?({ cst, cstMin, cstHour, cstString, options, users }: { cst: Date, cstMin: number, cstHour: number, cstString: string, options: options, users: Map<string, User> }): Promise<void>
   msg?({ message, options, users }: { message: raffleMessage | lotteryMessage | beatStormMessage, options: options, users: Map<string, User> }): Promise<void>
   notify?({ msg, options, users }: { msg: pluginNotify, options: options, users: Map<string, User> }): Promise<void>

--- a/bilive/app.ts
+++ b/bilive/app.ts
@@ -1,0 +1,3 @@
+const BiLive = require(__dirname + '/index').default
+const bilive = new BiLive()
+bilive.Start()

--- a/bilive/client_re.ts
+++ b/bilive/client_re.ts
@@ -1,6 +1,5 @@
 import tools from './lib/tools'
 import Client from './lib/client'
-import Options from './options'
 /**
  * 客户端, 可自动重连
  *
@@ -30,11 +29,12 @@ class ClientRE extends Client {
   /**
    * 更新服务器地址
    *
+   * @param string
    * @memberof ClientRE
    */
-  public Update() {
+  public Update(url: string) {
     this._update = true
-    const { 0: server, 1: protocol } = Options._.advConfig.serverURL.split('#')
+    const { 0: server, 1: protocol } = url.split('#')
     if (protocol !== undefined && protocol !== '') {
       this._server = server
       this._protocol = protocol

--- a/bilive/index.ts
+++ b/bilive/index.ts
@@ -37,7 +37,7 @@ class BiLive {
     Options.on('newUser', (user: User) => { // 新用户
       this._pluginList.forEach(plugin => { // 运行插件
         if (typeof plugin.start === 'function')
-          plugin.start({ options: Options._, users: new Map([[user.uid, user]]) })
+          plugin.start({ options: Options._, users: new Map([[user.uid, user]]) }, true)
       })
     })
     for (const uid in Options._.user) {
@@ -48,7 +48,7 @@ class BiLive {
     }
     this._pluginList.forEach(plugin => { // 运行插件
       if (typeof plugin.start === 'function')
-        plugin.start({ options: Options._, users: Options.user })
+        plugin.start({ options: Options._, users: Options.user }, false)
     })
     this.loop = setInterval(() => this._loop(), 55 * 1000)
     new WebAPI().Start()

--- a/bilive/lib/client.ts
+++ b/bilive/lib/client.ts
@@ -75,7 +75,9 @@ class Client extends EventEmitter {
   public Connect() {
     if (this._connected) return
     this._connected = true
-    this._wsClient = new ws(this._server, [this._protocol])
+    this._wsClient = new ws(this._server, [this._protocol], {
+      headers: { 'User-Agent': 'Bilive_Client 2.1.0.2105' }
+    })
     this._wsClient
       .on('error', error => this._ClientErrorHandler(error))
       .on('close', () => this.Close())

--- a/bilive/options.default.json
+++ b/bilive/options.default.json
@@ -12,6 +12,7 @@
   "advConfig": {
     "defaultUserID": 0,
     "serverURL": "wss://bilive.halaal.win/server/#164c48292a6c773c85716093589cd60e",
+    "bakServerURL": "",
     "eventRooms": [
       3
     ]
@@ -40,6 +41,11 @@
     },
     "serverURL": {
       "description": "监听服务器",
+      "tip": "用来监听房间抽奖消息, 格式为server#protocol",
+      "type": "string"
+    },
+    "bakServerURL": {
+      "description": "备用监听服务器",
       "tip": "用来监听房间抽奖消息, 格式为server#protocol",
       "type": "string"
     },

--- a/bilive/options.ts
+++ b/bilive/options.ts
@@ -12,18 +12,18 @@ class Options extends EventEmitter {
   constructor() {
     super()
     // 根据npm start参数不同设置不同路径
-    this._dirname = __dirname + (process.env.npm_package_scripts_start === 'node build/app.js' ? '/../..' : '/..')
+    this._dirname = __dirname + (process.env.npm_package_scripts_start === 'tsc-watch --onSuccess \"node build/app.js\"' ? '/../' : '')
     // 检查是否有options目录
-    const hasDir = fs.existsSync(this._dirname + '/options/')
-    if (!hasDir) fs.mkdirSync(this._dirname + '/options/')
+    const hasDir = fs.existsSync(this._dirname + 'options/')
+    if (!hasDir) fs.mkdirSync(this._dirname + 'options/')
     // 读取默认设置文件
-    const defaultOptionBuffer = fs.readFileSync(this._dirname + '/bilive/options.default.json')
+    const defaultOptionBuffer = fs.readFileSync(this._dirname + 'build/options.default.json')
     this._ = <options>JSON.parse(defaultOptionBuffer.toString())
     // 复制默认设置文件到用户设置文件
-    const hasFile = fs.existsSync(this._dirname + '/options/options.json')
-    if (!hasFile) fs.copyFileSync(this._dirname + '/bilive/options.default.json', this._dirname + '/options/options.json')
+    const hasFile = fs.existsSync(this._dirname + 'options/options.json')
+    if (!hasFile) fs.copyFileSync(this._dirname + 'build/options.default.json', this._dirname + 'options/options.json')
     // 读取用户设置文件
-    const userOptionBuffer = fs.readFileSync(this._dirname + '/options/options.json')
+    const userOptionBuffer = fs.readFileSync(this._dirname + 'options/options.json')
     this._userOption = <options>JSON.parse(userOptionBuffer.toString())
     if (this._ === undefined || this._userOption === undefined) throw new TypeError('文件格式化失败')
   }
@@ -66,6 +66,7 @@ class Options extends EventEmitter {
     'localListener',
     'defaultUserID',
     'serverURL',
+    'bakServerURL',
     'eventRooms',
     'adminServerChan',
     'user',

--- a/bilive/plugins/autoSend/index.ts
+++ b/bilive/plugins/autoSend/index.ts
@@ -50,7 +50,7 @@ class AutoSend extends Plugin {
         const day_limit = wearInfo.body.data.day_limit
         const today_feed = parseInt(wearInfo.body.data.today_feed)
         let intimacy_needed = day_limit - today_feed
-        if (intimacy_needed === 0) return tools.Log(user.nickname, `亲密度已达上限`)
+        if (intimacy_needed === 0) return tools.Log(user.nickname, `今日亲密度已达上限`)
         // 获取包裹信息
         const bag: requestOptions = {
           uri: `https://api.live.bilibili.com/gift/v2/gift/m_bag_list?${AppClient.signQueryBase(user.tokenQuery)}`,
@@ -64,7 +64,8 @@ class AutoSend extends Plugin {
             for (const giftData of bagInfo.body.data) {
               if (giftData.expireat > 0) {
                 let gift_value = 0
-                switch (giftData.gift_id) { // Gift_Config from http://api.live.bilibili.com/gift/v3/live/gift_config
+                // Gift_Config from http://api.live.bilibili.com/gift/v3/live/gift_config
+                switch (giftData.gift_id) {
                   case 1: gift_value = 1 //辣条
                     break
                   case 3: gift_value = 99 //B坷垃
@@ -98,7 +99,7 @@ class AutoSend extends Plugin {
                     if (intimacy_needed === 0) return tools.Log(user.nickname, `亲密度已达上限`)
                   }
                   else tools.Log(user.nickname, '自动送礼V2', `向房间 ${room_id} 赠送 ${send_num} 个${giftData.gift_name} 失败`, sendBag.body)
-                  await tools.Sleep(5 * 1000)
+                  await tools.Sleep(3 * 1000)
                 }
               }
             }

--- a/bilive/plugins/autoUpdate/index.ts
+++ b/bilive/plugins/autoUpdate/index.ts
@@ -1,0 +1,143 @@
+import fs from 'fs'
+import { exec } from 'child_process'
+import Plugin, { tools } from '../../plugin'
+
+class AutoUpdate extends Plugin {
+  constructor() {
+    super()
+  }
+  public name = '自动更新'
+  public description = '自动更新本地git'
+  public version = '0.0.2'
+  public author = 'Vector000'
+  public async load() {
+    this.loaded = true
+  }
+  public async start({}, newUser: boolean) {
+    if (!newUser) this._checkForUpdate()
+  }
+  public async loop({ cstMin, cstHour }: { cstMin: number, cstHour: number }) {
+    if (cstMin === 0 && cstHour % 12 === 6) this._checkForUpdate()
+  }
+  // 根目录路径
+  private _dirname = __dirname + (process.env.npm_package_scripts_start === 'tsc-watch --onSuccess \"node build/app.js\"' ? '/../../..' : '/../..')
+  /**
+   * 检查当前应用目录是否有对应git仓库
+   *
+   * @private
+   * 
+   */
+  private async _checkPath(dir: string) {
+    if (fs.existsSync(`${dir}/.git`)) return true
+    else return false
+  }
+  /**
+   * 运行指定命令，并返回输出
+   * 
+   * @param {string} cmd
+   * @private
+   */
+  private async execCMD(cmd: string) {
+    return new Promise<string | undefined>(resolve => {
+      exec(cmd, (error: any, stdout: any, stderr: any) => {
+        if (error) {
+          tools.ErrorLog(error)
+          resolve()
+        }
+        if (stderr) {
+          tools.ErrorLog(stderr)
+          resolve()
+        }
+        resolve(stdout)
+      })
+    })
+  }
+  /**
+   * git branch, 获取当前的git分支
+   * 
+   * @private
+   */
+  private async gitBranch() {
+    let branches = await this.execCMD('git branch')
+    if (branches === undefined) return tools.ErrorLog(`获取本地分支信息失败`)
+    let realBranch: string = ''
+    let branchArr = branches.split('\n')
+    branchArr.forEach((branch: string) => {
+      if (branch[0] === '*') realBranch = branch.substr(2)
+    })
+    return realBranch
+  }
+  /**
+   * 获取当前本地分支的commit hash
+   * 
+   * @private
+   */
+  private async getLocalCommitHash() {
+    return await this.execCMD('git rev-parse HEAD')
+  }
+  /**
+   * 获取远端文件
+   *
+   * @private
+   */
+  private async fetchRemote() {
+    return await this.execCMD('git fetch')
+  }
+  /**
+   * 获取对应远程分支的commit hash
+   * 
+   * @private
+   */
+  private async getRemoteCommitHash(branch: string) {
+    return await this.execCMD(`git rev-parse origin/${branch}`)
+  }
+  /**
+   * git merge
+   * 
+   * @private
+   */
+  private async gitMerge() {
+    return await this.execCMD('git merge')
+  }
+  /**
+   * 更新设置页面
+   * 
+   * @private
+   */
+  private async updateDocs() {
+    return await this.execCMD('npm run build:view')
+  }
+  /**
+   * 检查更新
+   * 
+   * @private
+   * 
+   */
+  private async _checkForUpdate() {
+    const pathStatus = await this._checkPath(this._dirname)
+    if (!pathStatus) return tools.Log(`未发现git仓库，无法进行自动更新，建议查阅README.md进行重新安装！`)
+    else {
+      tools.Log(`正在查询更新......`)
+      let branch = await this.gitBranch()
+      if (branch === undefined || branch === '') return tools.ErrorLog(`获取本地分支信息失败`)
+      let localHash = await this.getLocalCommitHash()
+      if (localHash === undefined) return tools.ErrorLog(`获取本地commit信息失败`)
+      let fetchStatus = await this.fetchRemote()
+      if (fetchStatus === undefined) return tools.ErrorLog(`获取最新版本失败`)
+      let remoteHash = await this.getRemoteCommitHash(branch)
+      if (remoteHash === undefined) return tools.ErrorLog(`获取最新版本信息失败`)
+      if (localHash === remoteHash) {
+        tools.Log(`当前版本 (${branch}@${localHash.substr(0,8)}) 已是最新版本`)
+        this.updateDocs()
+      }
+      else {
+        tools.Log(`发现新版本 (${branch}@${remoteHash.substr(0,8)}) 10秒后开始更新 可能会重启数次`)
+        tools.sendSCMSG(`发现新版本 即将进行自动升级`)
+        await tools.Sleep(10 * 1000)
+        await this.gitMerge()
+      }
+    }
+  }
+}
+
+export default new AutoUpdate()

--- a/bilive/plugins/raffle/index.ts
+++ b/bilive/plugins/raffle/index.ts
@@ -1,5 +1,6 @@
 import Lottery from './raffle'
 import Plugin, { tools } from '../../plugin'
+import Options from '../../options'
 
 class Raffle extends Plugin {
   constructor() {
@@ -17,6 +18,8 @@ class Raffle extends Plugin {
   private _stormBanList: Map<string, boolean> = new Map()
   // 风暴限制列表
   private _stormEarn: any = {}
+  // 上次raffle时间
+  private _lastRaffleTime: number = Date.now()
   public async load({ defaultOptions, whiteList }: { defaultOptions: options, whiteList: Set<string> }) {
     // 抽奖暂停
     defaultOptions.config['rafflePause'] = []
@@ -34,6 +37,14 @@ class Raffle extends Plugin {
       type: 'numberArray'
     }
     whiteList.add('stormSetting')
+    // 节奏并发用户数现在
+    defaultOptions.advConfig['stormUserLimit'] = 3
+    defaultOptions.info['stormUserLimit'] = {
+      description: '节奏用户限制',
+      tip: '同一时间允许参与节奏风暴抽奖的用户数量限制',
+      type: 'number'
+    }
+    whiteList.add('stormUserLimit')
     // 非beatStorm类抽奖的全局延迟
     defaultOptions.advConfig['raffleDelay'] = 3000
     defaultOptions.info['raffleDelay'] = {
@@ -106,15 +117,72 @@ class Raffle extends Plugin {
       type: 'number'
     }
     whiteList.add('beatStormLimit')
+    // beatStorm优先级
+    defaultOptions.newUserData['beatStormPriority'] = 0
+    defaultOptions.info['beatStormPriority'] = {
+      description: '风暴优先级',
+      tip: '各用户领取风暴的优先级，优先级较低的用户会受并发控制而不参与抽奖',
+      type: 'number'
+    }
+    whiteList.add('beatStormPriority')
+    // beatStorm领取量
+    defaultOptions.newUserData['beatStormTaken'] = 0
+    whiteList.add('beatStormTaken')
+    // beatStorm刷新时间
+    defaultOptions.advConfig['beatStormRefresh'] = Date.now()
+    whiteList.add('beatStormRefresh')
     this.loaded = true
   }
+  /**
+   * 领取数量清零
+   * 
+   * @param users 
+   * @private
+   */
   private async _refreshCount(users: Map<string, User>) {
-    users.forEach(user => {
-      this._stormEarn[user.uid] = 0
-    })
+    users.forEach(user => this._stormEarn[user.uid] = 0)
   }
-  public async start({ users }: { users: Map<string, User> }) {
+  /**
+   * 加载领取数量
+   * 
+   * @param options 
+   * @param users 
+   * @private
+   */
+  private async _loadCount(options: options, users: Map<string, User>) {
+    const cst = new Date(Date.now() + 8 * 60 * 60 * 1000)
+    const cstHour = cst.getUTCHours()
+    const cstMin = cst.getUTCMinutes()
+    const cstSec = cst.getUTCSeconds()
+    const todaySecondsPassed = cstHour * 3600 + cstMin * 60 + cstSec
+    if (Date.now() - <number>options.advConfig['beatStormRefresh'] < todaySecondsPassed * 1000)
+      users.forEach(async (user, uid) => this._stormEarn[uid] = user.userData['beatStormTaken'])
+  }
+  /**
+   * 计算优先级，确定用户是否允许抽奖
+   * 
+   * @param users 
+   * @private
+   * @returns {number}
+   */
+  private async _getPriorityLimit(options: options, users: Map<string, User>) {
+    let userPriority: Map<number, string> = new Map()
+    users.forEach(async (user, uid) => {
+      if (this._raffleBanList.get(uid) || this._stormBanList.get(uid)) return
+      if (!user.userData['beatStorm']) return
+      if (this._stormEarn[uid] !== undefined && this._stormEarn[uid] >= <number>user.userData['beatStormLimit']) return
+      userPriority.set(<number>user.userData['beatStormPriority'], uid)
+    })
+    let priorityDec = new Map([...userPriority.entries()].sort())
+    let priorityKeysArr = [...priorityDec.keys()]
+    let order = priorityKeysArr.length - <number>options.advConfig['stormUserLimit']
+    if (order < 0) order = 0
+    let priorityKey = priorityKeysArr[order]
+    return priorityKey
+  }
+  public async start({ options, users }: { options: options, users: Map<string, User> }) {
     this._refreshCount(users)
+    this._loadCount(options, users)
   }
   public async loop({ cstMin, cstHour, cstString, options, users }: { cstMin: number, cstHour: number, cstString: string, options: options, users: Map<string, User> }) {
     // 抽奖暂停
@@ -126,38 +194,83 @@ class Raffle extends Plugin {
       else this._raffle = true
     }
     else this._raffle = true
-    if (cstString === '00:00') this._refreshCount(users)
     if (cstMin === 0 && cstHour % 12 === 0) {
       this._raffleBanList.clear()
       this._stormBanList.clear()
     }
+    if (cstString === '00:00') this._refreshCount(users)
+    // 当天数据写入JSON
+    users.forEach(async (user, uid) => user.userData['beatStormTaken'] = this._stormEarn[uid])
+    options.advConfig['beatStormRefresh'] = Date.now()
+    Options.save()
   }
   public async msg({ message, options, users }: { message: raffleMessage | lotteryMessage | beatStormMessage, options: options, users: Map<string, User> }) {
     if (this._raffle) {
-      users.forEach(async (user, uid) => {
-        if (user.captchaJPEG !== '' || !user.userData[message.cmd]) return
-        if (this._raffleBanList.get(uid)) return
-        if (this._stormBanList.get(uid) && message.cmd === 'beatStorm') return
-        if (this._stormEarn[uid] !== undefined && message.cmd === 'beatStorm' && this._stormEarn[uid] >= <number>user.userData['beatStormLimit']) return
-        const droprate = message.cmd === 'beatStorm' ? <number>options.advConfig['beatStormDrop'] : <number>options.advConfig['raffleDrop']
-        if (droprate !== 0 && Math.random() < droprate / 100) tools.Log(user.nickname, '丢弃抽奖', message.id)
-        else {
-          const delay = message.cmd === 'beatStorm' ? <number>options.advConfig['beatStormDelay'] : <number>options.advConfig['raffleDelay']
-          await tools.Sleep(delay)
-          const lottery = new Lottery(message, user)
-          lottery
-            .on('msg', (msg: pluginNotify) => {
-              if (msg.cmd === 'ban') {
-                if (msg.data.type === 'raffle') this._raffleBanList.set(msg.data.uid, true)
-                else this._stormBanList.set(msg.data.uid, true)
-              }
-              if (msg.cmd === 'earn' && msg.data.type === 'beatStorm') this._stormEarn[uid]++
-              this.emit('msg', msg)
-            })
-            .Start()
-        }
-      })
+      if (message.cmd === 'beatStorm') this._doStorm({message, options, users})
+      else {
+        if (Date.now() - this._lastRaffleTime < 400) await tools.Sleep(400)
+        this._lastRaffleTime = Date.now()
+        this._doRaffle({message, options, users})
+      }
     }
+  }
+  /**
+   * 进行raffle类抽奖
+   * 
+   * @param {message, options, users}
+   * @private
+   */
+  private async _doRaffle({ message, options, users }: { message: raffleMessage | lotteryMessage, options: options, users: Map<string, User> }) {
+    const delay = <number>options.advConfig['raffleDelay']
+    if (delay !== 0) await tools.Sleep(delay)
+    for (let [uid, user] of users) {
+      if (user.captchaJPEG !== '' || !user.userData[message.cmd]) continue
+      if (this._raffleBanList.get(uid)) continue
+      const droprate = <number>options.advConfig['raffleDrop']
+      if (droprate !== 0 && Math.random() < droprate / 100) {
+        tools.Log(user.nickname, '丢弃抽奖', message.id)
+        continue
+      }
+      else {
+        const lottery = new Lottery(message, user)
+        lottery
+          .on('msg', (msg: pluginNotify) => {
+            if (msg.cmd === 'ban') this._raffleBanList.set(msg.data.uid, true)
+            this.emit('msg', msg)
+          })
+          .Start()
+      }
+      await tools.Sleep(100)
+    }
+  }
+  /**
+   * 进行beatStorm类抽奖
+   * 
+   * @param {message, options, users}
+   * @private
+   */
+  private async _doStorm({ message, options, users }: { message: beatStormMessage, options: options, users: Map<string, User> }) {
+    const stormPriorityTheshold = await this._getPriorityLimit(options, users)
+    users.forEach(async (user, uid) => {
+      if (user.captchaJPEG !== '' || !user.userData['beatStorm']) return
+      if (this._raffleBanList.get(uid) || this._stormBanList.get(uid)) return
+      if (this._stormEarn[uid] !== undefined && this._stormEarn[uid] >= <number>user.userData['beatStormLimit']) return
+      if (<number>user.userData['beatStormPriority'] < stormPriorityTheshold) return
+      const droprate = <number>options.advConfig['beatStormDrop']
+      if (droprate !== 0 && Math.random() < droprate / 100) tools.Log(user.nickname, '丢弃抽奖', message.id)
+      else {
+        const delay = <number>options.advConfig['beatStormDelay']
+        if (delay !== 0) await tools.Sleep(delay)
+        const lottery = new Lottery(message, user)
+        lottery
+          .on('msg', (msg: pluginNotify) => {
+            if (msg.cmd === 'ban') this._stormBanList.set(msg.data.uid, true)
+            if (msg.cmd === 'earn') this._stormEarn[uid]++
+            this.emit('msg', msg)
+          })
+          .Start()
+      }
+    })
   }
 }
 

--- a/bilive/plugins/raffle/raffle.ts
+++ b/bilive/plugins/raffle/raffle.ts
@@ -108,6 +108,10 @@ class Raffle extends EventEmitter {
         if (raffleAward.body.code === 0) {
           const gift = raffleAward.body.data
           if (gift.gift_num === 0) tools.Log(this._user.nickname, title, id, raffleAward.body.msg)
+          if (gift.gift_num === undefined) {
+            tools.Log(raffleAward.body)
+            tools.sendSCMSG(raffleAward.body.toString())
+          }
           else {
             const msg = `${this._user.nickname} ${title} ${id} 获得 ${gift.gift_num} 个${gift.gift_name}`
             this.emit('msg', {
@@ -189,19 +193,17 @@ class Raffle extends EventEmitter {
         const content = joinStorm.body.data
         if (content !== undefined && content.gift_num > 0) {
           tools.Log(this._user.nickname, title, id, `第${i}次尝试`, `${content.mobile_content} 获得 ${content.gift_num} 个${content.gift_name}`)
-          this.emit('msg', {
-            cmd: 'earn',
-            data: { uid: this._user.uid, nickname: this._user.nickname, type: 'beatStorm', name: content.gift_name, num: content.gift_num }
-          })
+          this.emit('msg', { cmd: 'earn', data: { uid: this._user.uid, nickname: this._user.nickname, type: 'beatStorm', name: content.gift_name, num: content.gift_num } })
           break
         }
       }
-      else tools.Log(this._user.nickname, title, id, `第${i}次尝试`, joinStorm.body.msg)
-      if (joinStorm.body.msg === '已经领取奖励') break
       else if (joinStorm.body.msg === '访问被拒绝') {
         this.emit('msg', { cmd: 'ban', data: { uid: this._user.uid, type: 'beatStorm', nickname: this._user.nickname } })
         break
       }
+      else if (joinStorm.body.msg === '已经领取奖励') break
+      else tools.Log(this._user.nickname, title, id, `第${i}次尝试`, joinStorm.body.msg)
+      if (joinStorm.body.msg === '你错过了奖励，下次要更快一点哦~') this.emit('msg', { cmd: 'unban', data: { uid: this._user.uid, type: 'beatStorm', nickname: this._user.nickname } })
       await tools.Sleep((<number[]>Options._.advConfig.stormSetting)[0])
     }
   }

--- a/bilive/webapi.ts
+++ b/bilive/webapi.ts
@@ -169,6 +169,7 @@ class WebAPI extends EventEmitter {
       case 'setAdvConfig': {
         const config = Options._.advConfig
         const serverURL = config.serverURL
+        const bakServerURL = config.bakServerURL
         const setConfig = <config>message.data || {}
         let msg = ''
         for (const i in config) {
@@ -184,6 +185,7 @@ class WebAPI extends EventEmitter {
           Options.save()
           this._Send({ cmd, ts, data: config })
           if (serverURL !== config.serverURL) Options.emit('clientUpdate')
+          if (bakServerURL !== config.bakServerURL) Options.emit('bakClientUpdate')
         }
         else this._Send({ cmd, ts, msg, data: config })
       }

--- a/docs/script.ts
+++ b/docs/script.ts
@@ -317,6 +317,7 @@ function getConfigTemplate(config: config | userData): DocumentFragment {
 function wsClose(data: string) {
   const connectSpan = <HTMLSpanElement>loginDiv.querySelector('#connect span')
   configDiv.innerText = ''
+  advConfigDiv.innerHTML = ''
   logDiv.innerText = ''
   userDiv.innerText = ''
   connectSpan.innerText = data

--- a/package.json
+++ b/package.json
@@ -1,33 +1,47 @@
 {
   "name": "bilive_client",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "基于Node.JS的bilibili直播挂机系统",
   "main": "index.js",
   "scripts": {
     "build": "npm run build:client && npm run build:view",
     "build:client": "tsc -p tsconfig.json && npm-run-posix-or-windows copy:client",
     "build:view": "tsc -p docs/tsconfig.json && npm-run-posix-or-windows copy:view",
-    "copy:client": "cp bilive/options.default.json build/bilive/",
-    "copy:client:windows": "xcopy bilive\\options.default.json build\\bilive\\ /Y",
+    "copy:client": "cp bilive/options.default.json build/",
+    "copy:client:windows": "xcopy bilive\\options.default.json build\\ /Y",
     "copy:view": "cp -r docs/view/ docs/index.html build/",
     "copy:view:windows": "xcopy docs\\view\\* build\\view\\ /Y && xcopy docs\\index.html build\\ /Y",
-    "clean": "rimraf build",
-    "start": "node build/app.js"
+    "clean": "rimraf build && mkdir build",
+    "test": "node build/app.js",
+    "prestart": "npm run clean && npm run build:view && npm-run-posix-or-windows copy:client",
+    "start": "tsc-watch --onSuccess \"node build/app.js\""
   },
-  "author": "lzghzr",
+  "config": {
+    "commitizen": {
+      "path": "./node_modules/cz-conventional-changelog"
+    }
+  },
+  "homepage": "https://github.com/Vector000/bilive_client#readme",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Vector000/bilive_client.git"
+  },
+  "author": "Vector000",
   "license": "MIT",
   "devDependencies": {
-    "@types/bootstrap": "^4.2.1",
-    "@types/jquery": "^3.3.27",
-    "@types/node": "^10.12.15",
+    "cz-conventional-changelog": "^2.1.0"
+  },
+  "dependencies": {
+    "@types/bootstrap": "^4.3.0",
+    "@types/jquery": "^3.3.29",
+    "@types/node": "^10.14.4",
     "@types/request": "^2.48.1",
     "@types/ws": "^6.0.1",
     "npm-run-posix-or-windows": "^2.0.2",
-    "rimraf": "^2.6.3",
-    "typescript": "^3.2.4"
-  },
-  "dependencies": {
     "request": "^2.88.0",
-    "ws": "^6.1.3"
+    "rimraf": "^2.6.3",
+    "tsc-watch": "^2.1.2",
+    "typescript": "^3.4.1",
+    "ws": "^6.2.1"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "sourceMap": false,                       /* 生成相应的 ".map" 文件。 */
     // "outFile": "./",                       /* 连接输出并将其发出到单个文件。 */
     "outDir": "build",                        /* 将输出结构重定向到目录。 */
-    // "rootDir": "./",                       /* 指定输入文件的根目录。与 --outDir 一起用于控制输出目录结构。 */
+    "rootDir": "bilive",                       /* 指定输入文件的根目录。与 --outDir 一起用于控制输出目录结构。 */
     "removeComments": true,                   /* 请勿将注释发出到输出。 */
     // "noEmit": true,                        /* 请勿发出输出。 */
     // "importHelpers": true,                 /* 从 "tslib" 导入发出帮助程序。 */


### PR DESCRIPTION
- 利用tsc-watch对源码目录进行监听，定期执行git fetch并对比本地和远程分支，从而实现自动更新
- feat(listener): 添加了连接备用ws服务器，实现双监听服务器的功能
- feat(raffle): 加入了限制节奏风暴同时参与用户数量的功能
- perf(raffle): 优化了raffle抽奖逻辑，加入了抽奖间延迟/用户参与间延迟
- fix(getStatus): 优化逻辑，修复了每次重启都会报封禁信息的问题
- fix(getStatus): 修复了推送间隔设置的问题
- 顺便改了一下README.md，加了几个好看的(wu)的badge

BREAKING CHANGE: 使用tsc-watch运行ts编译，而且目录树也有一定调整

	使用前必须重新使用npm install安装依赖！