### PR TITLE
[pm2 fixed]: 修复在pm2守护进程中运行错误

### DIFF
--- a/bilive/options.ts
+++ b/bilive/options.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'events'
 import fs from 'fs'
+import path from 'path'
 import util from 'util'
 const FSwriteFile = util.promisify(fs.writeFile)
 /**
@@ -12,7 +13,9 @@ class Options extends EventEmitter {
   constructor() {
     super()
     // 根据npm start参数不同设置不同路径
-    this._dirname = __dirname + (process.env.npm_package_scripts_start === 'tsc-watch --onSuccess \"node build/app.js\"' ? '/../' : '')
+    // this._dirname = __dirname + (process.env.npm_package_scripts_start === 'tsc-watch --onSuccess \"node build/app.js\"' ? '/../' : '')
+    // bugkun(nopast)：修复pm2下路径出错的问题
+    this._dirname = path.join(process.cwd(), '/')
     // 检查是否有options目录
     const hasDir = fs.existsSync(this._dirname + 'options/')
     if (!hasDir) fs.mkdirSync(this._dirname + 'options/')

--- a/pm2.json
+++ b/pm2.json
@@ -1,0 +1,15 @@
+﻿{
+    "apps": [{
+      "name": "bilive_client",
+      "script": "./build/app.js",
+      "cwd": "./",
+      "exec_mode": "fork",
+      "max_memory_restart": "1G",
+      "autorestart": true,
+      "node_args": [],
+      "args": [],
+      "env": {
+        
+      }
+    }]
+  }


### PR DESCRIPTION
# 修复在pm2守护进程中运行错误

## 使用方法
* 确保已正常安装<a href="https://www.npmjs.com/package/pm2">pm2</a>
* `npm run build` 把ts构建成js文件
* `pm2 start ./pm2.json`