### PR TITLE
新增功能：httpApi

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+[*.{js,jsx,ts,tsx,vue}]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 100

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 logs
 *.log
 npm-debug.log*
+yarn.lock
 
 # Runtime data
 pids
@@ -47,3 +48,6 @@ package-lock.json
 temp
 docs/view/options.js
 docs/view/script.js
+
+# ide file
+.idea

--- a/README.md
+++ b/README.md
@@ -48,6 +48,37 @@
 * 现在提供了远程连接数据加密的功能，默认关闭（无密钥）
 * 需要打开的用户可以在设置页面中设置密钥（建议最好是直接修改json）
 
+## HttpApi 相关
+请求地址 => http(s)://ip:你设置的端口(options.server.port)/api
+
+请求方式 => POST
+
+请求参数 => Header 包含 authorization 值为 options.server.protocol
+
+具体接口和参数与 ws 操作一致，返回内容一致，具体传入和传出参数请参照 [webapi.ts](./blob/master/bilive/webapi.ts)
+
+
+目前有
+```json
+{
+    "getLog": "获取日志",
+    "getConfig": "获取配置",
+    "setConfig": "设置配置",
+    "getAdvConfig": "获取高级设置",
+    "setAdvConfig": "设置高级设置",
+    "setNewNetkey": "修改密钥",
+    "getInfo": "获取参数描述",
+    "getAllUID": "获取uid",
+    "getUserData": "获取用户配置",
+    "setUserData": "设置用户配置",
+    "delUserData": "删除用户",
+    "newUserData": "新增用户",
+    "getAllUtilID": "获取util ID",
+    "getUtilData": "获取utilData",
+    "utilMSG": "接收util数据，触发对应util"
+}
+```
+
 ## 服务端相关
 
 * [原作者](https://github.com/lzghzr/)大佬的服务器11月到期，现提供一个备用服务端`ws://47.101.153.223:20080/#ff5f0db2548baecbcd21c7a50ece57a3`，目前续费到12月，后续应该也会继续续上(无限+1s)，欢迎各种花式投喂

--- a/bilive/webapi.ts
+++ b/bilive/webapi.ts
@@ -1,12 +1,14 @@
 import ws from 'ws'
 import fs from 'fs'
 import http from 'http'
-import { randomBytes } from 'crypto'
-import { EventEmitter } from 'events'
+import {randomBytes} from 'crypto'
+import {EventEmitter} from 'events'
 import tools from './lib/tools'
 import User from './online'
 import Options from './options'
-const { B64XorCipher } = tools
+
+const {B64XorCipher} = tools
+
 /**
  * 程序设置
  *
@@ -17,7 +19,9 @@ class WebAPI extends EventEmitter {
   constructor() {
     super()
   }
+
   private _wsClient!: ws
+
   /**
    * 启动HTTP以及WebSocket服务
    *
@@ -26,6 +30,7 @@ class WebAPI extends EventEmitter {
   public Start() {
     this._HttpServer()
   }
+
   /**
    * HTTP服务
    *
@@ -35,10 +40,31 @@ class WebAPI extends EventEmitter {
   private _HttpServer() {
     // 直接跳转到coding.me, 为防以后变更使用302
     const server = http.createServer((req, res) => {
-      req.on('error', error => tools.ErrorLog('req', error))
-      res.on('error', error => tools.ErrorLog('res', error))
-      res.writeHead(302, { 'Location': '//vector000.coding.me/bilive_setting/' })
-      res.end()
+      const error = () => {
+        req.on('error', error => tools.ErrorLog('req', error))
+        res.on('error', error => tools.ErrorLog('res', error))
+        res.writeHead(302, {'Location': '//vector000.coding.me/bilive_setting/'})
+        res.end()
+      }
+      if (req.method && req.method.toLocaleLowerCase() === 'post' && req.url === '/api') {
+        if (req.headers.authorization === Options._.server.protocol) {
+          let alldata = '';
+          req.on('data', function (chunk) {
+            alldata += chunk;
+          });
+          res.writeHead(200, {"Content-Type": "application/json"});
+          req.on('end', () => {
+            const message: message = JSON.parse(alldata);
+            if (message !== undefined && message.cmd !== undefined && message.ts !== undefined) {
+              this._onCMD(message).then(response => {
+                res.end(JSON.stringify(response))
+              })
+            } else {
+              res.end(JSON.stringify({cmd: 'error', ts: 'error', msg: '消息格式错误'}))
+            }
+          });
+        } else error()
+      } else error()
     }).on('error', error => tools.ErrorLog('http', error))
     // 监听地址优先支持Unix Domain Socket
     const listen = Options._.server
@@ -49,8 +75,7 @@ class WebAPI extends EventEmitter {
         this._WebSocketServer(server)
         tools.Log(`已监听 ${host}:${port}`)
       })
-    }
-    else {
+    } else {
       if (fs.existsSync(listen.path)) fs.unlinkSync(listen.path)
       server.listen(listen.path, () => {
         fs.chmodSync(listen.path, '666')
@@ -59,6 +84,7 @@ class WebAPI extends EventEmitter {
       })
     }
   }
+
   /**
    * WebSocket服务
    *
@@ -84,9 +110,12 @@ class WebAPI extends EventEmitter {
           : `${req.headers['x-real-ip']}:${req.headers['x-real-port']}`
         tools.Log(`${remoteAddress} 已连接`)
         // 限制同时只能连接一个客户端
-        if (this._wsClient !== undefined) this._wsClient.close(1001, JSON.stringify({ cmd: 'close', msg: 'too many connections' }))
+        if (this._wsClient !== undefined) this._wsClient.close(1001, JSON.stringify({
+          cmd: 'close',
+          msg: 'too many connections'
+        }))
         // 使用function可能出现一些问题, 此处无妨
-        const onLog = (data: string) => this._Send({ cmd: 'log', ts: 'log', msg: data })
+        const onLog = (data: string) => this._Send({cmd: 'log', ts: 'log', msg: data})
         const destroy = () => {
           tools.removeListener('log', onLog)
           client.close()
@@ -104,8 +133,11 @@ class WebAPI extends EventEmitter {
           })
           .on('message', async (msg: string) => {
             const message = await tools.JSONparse<message>(B64XorCipher.decode(Options._.server.netkey || '', msg))
-            if (message !== undefined && message.cmd !== undefined && message.ts !== undefined) this._onCMD(message)
-            else this._Send({ cmd: 'error', ts: 'error', msg: '消息格式错误' })
+            if (message !== undefined && message.cmd !== undefined && message.ts !== undefined) {
+              this._onCMD(message).then(res => {
+                this._Send(res);
+              })
+            } else this._Send({cmd: 'error', ts: 'error', msg: '消息格式错误'})
           })
         // 一般推荐客户端发送心跳, 不过放在服务端的话可以有一些限制 (目前没有)
         const ping = setInterval(() => {
@@ -117,12 +149,11 @@ class WebAPI extends EventEmitter {
         tools.on('log', onLog)
       })
   }
+
   /**
    * 监听客户端发来的消息, CMD为关键字
-   *
+   * @param message
    * @private
-   * @param {message} message
-   * @memberof WebAPI
    */
   private async _onCMD(message: message) {
     const cmd = message.cmd
@@ -131,15 +162,14 @@ class WebAPI extends EventEmitter {
       // 获取log
       case 'getLog': {
         const data = tools.logs
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
       // 获取设置
       case 'getConfig': {
         const data = Options._.config
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
+
       // 保存设置
       case 'setConfig': {
         const config = Options._.config
@@ -149,24 +179,23 @@ class WebAPI extends EventEmitter {
           if (typeof config[i] !== typeof setConfig[i]) {
             // 一般都是自用, 做一个简单的验证就够了
             msg = i + '参数错误'
-            break
+
           }
         }
         if (msg === '') {
           // 防止setConfig里有未定义属性, 不使用Object.assign
           for (const i in config) config[i] = setConfig[i]
           Options.save()
-          this._Send({ cmd, ts, data: config })
-        }
-        else this._Send({ cmd, ts, msg, data: config })
+          return {cmd, ts, data: config}
+        } else return {cmd, ts, msg, data: config}
       }
-        break
+
       // 获取高级设置
       case 'getAdvConfig': {
         const data = Options._.advConfig
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
+
       // 保存高级设置
       case 'setAdvConfig': {
         const config = Options._.advConfig
@@ -178,50 +207,54 @@ class WebAPI extends EventEmitter {
           if (typeof config[i] !== typeof setConfig[i]) {
             // 一般都是自用, 做一个简单的验证就够了
             msg = i + '参数错误'
-            break
+
           }
         }
         if (msg === '') {
           // 防止setAdvConfig里有未定义属性, 不使用Object.assign
           for (const i in config) config[i] = setConfig[i]
           Options.save()
-          this._Send({ cmd, ts, data: config })
+          return {cmd, ts, data: config}
           if (serverURL !== config.serverURL) Options.emit('clientUpdate')
           if (bakServerURL !== config.bakServerURL) Options.emit('bakClientUpdate')
-        }
-        else this._Send({ cmd, ts, msg, data: config })
+        } else return {cmd, ts, msg, data: config}
       }
-        break
+
       // 修改密钥
       case 'setNewNetkey': {
         const server = Options._.server
         const config = <any>message.data || {}
         server.netkey = config.netkey || ''
         Options.save()
-        
-        this._Send({ cmd, ts })
+
+        return {cmd, ts}
       }
-        break
+
       // 获取参数描述
       case 'getInfo': {
         const data = Options._.info
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
+
       // 获取uid
       case 'getAllUID': {
         const data = Object.keys(Options._.user)
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
+
       // 获取用户设置
       case 'getUserData': {
         const user = Options._.user
         const getUID = message.uid
-        if (typeof getUID === 'string' && user[getUID] !== undefined) this._Send({ cmd, ts, uid: getUID, data: user[getUID] })
-        else this._Send({ cmd, ts, msg: '未知用户' })
+        if (typeof getUID === 'string' && user[getUID] !== undefined) return {
+          cmd,
+          ts,
+          uid: getUID,
+          data: user[getUID]
+        }
+        else return {cmd, ts, msg: '未知用户'}
       }
-        break
+
       // 保存用户设置
       case 'setUserData': {
         const user = Options._.user
@@ -234,7 +267,7 @@ class WebAPI extends EventEmitter {
           for (const i in userData) {
             if (typeof userData[i] !== typeof setUserData[i]) {
               msg = i + '参数错误'
-              break
+
             }
           }
           if (msg === '') {
@@ -246,8 +279,7 @@ class WebAPI extends EventEmitter {
               // 账号会尝试登录, 如果需要验证码status会返回'captcha', 并且验证码会以DataUrl形式保存在captchaJPEG
               if (status === 'captcha') captcha = newUser.captchaJPEG
               else if (Options.user.has(setUID)) Options.emit('newUser', newUser)
-            }
-            else if (userData.status && Options.user.has(setUID)) {
+            } else if (userData.status && Options.user.has(setUID)) {
               // 对于已经存在的用户, 可能处在验证码待输入阶段
               const captchaUser = <User>Options.user.get(setUID)
               if (captchaUser.captchaJPEG !== '' && message.captcha !== undefined) {
@@ -257,17 +289,14 @@ class WebAPI extends EventEmitter {
                 if (status === 'captcha') captcha = captchaUser.captchaJPEG
                 else if (Options.user.has(setUID)) Options.emit('newUser', captchaUser)
               }
-            }
-            else if (!userData.status && Options.user.has(setUID)) (<User>Options.user.get(setUID)).Stop()
+            } else if (!userData.status && Options.user.has(setUID)) (<User>Options.user.get(setUID)).Stop()
             Options.save()
-            if (captcha === '') this._Send({ cmd, ts, uid: setUID, data: userData })
-            else this._Send({ cmd, ts, uid: setUID, msg: 'captcha', data: userData, captcha })
-          }
-          else this._Send({ cmd, ts, uid: setUID, msg, data: userData })
-        }
-        else this._Send({ cmd, ts, uid: setUID, msg: '未知用户' })
+            if (captcha === '') return {cmd, ts, uid: setUID, data: userData}
+            else return {cmd, ts, uid: setUID, msg: 'captcha', data: userData, captcha}
+          } else return {cmd, ts, uid: setUID, msg, data: userData}
+        } else return {cmd, ts, uid: setUID, msg: '未知用户'}
       }
-        break
+
       // 删除用户设置
       case 'delUserData': {
         const user = Options._.user
@@ -277,11 +306,10 @@ class WebAPI extends EventEmitter {
           delete Options._.user[delUID]
           if (Options.user.has(delUID)) (<User>Options.user.get(delUID)).Stop()
           Options.save()
-          this._Send({ cmd, ts, uid: delUID, data: userData })
-        }
-        else this._Send({ cmd, ts, uid: delUID, msg: '未知用户' })
+          return {cmd, ts, uid: delUID, data: userData}
+        } else return {cmd, ts, uid: delUID, msg: '未知用户'}
       }
-        break
+
       // 新建用户设置
       case 'newUserData': {
         // 虽然不能保证唯一性, 但是这都能重复的话可以去买彩票
@@ -290,43 +318,49 @@ class WebAPI extends EventEmitter {
         Options.whiteList.add(uid)
         Options._.user[uid] = data
         Options.save()
-        this._Send({ cmd, ts, uid, data })
+        return {cmd, ts, uid, data}
       }
-        break
+
       // 获取util ID
       case 'getAllUtilID': {
         const data = Object.keys(Options._.util)
-        this._Send({ cmd, ts, data })
+        return {cmd, ts, data}
       }
-        break
+
       // 获取utilData
       case 'getUtilData': {
         const util = Options._.util
         const getUtilID = message.utilID
-        if (typeof getUtilID === 'string' && util[getUtilID] !== undefined) this._Send({ cmd, ts, uid: getUtilID, data: util[getUtilID] })
-        else this._Send({ cmd, ts, msg: '错误：未知功能插件' })
+        if (typeof getUtilID === 'string' && util[getUtilID] !== undefined) return {
+          cmd,
+          ts,
+          uid: getUtilID,
+          data: util[getUtilID]
+        }
+        else return {cmd, ts, msg: '错误：未知功能插件'}
       }
-        break
+
       // 接收util数据，触发对应util
-      case 'utilMSG': this.emit('utilMSG', message)
-        break
-      // 未知命令
-      default:
-        this._Send({ cmd, ts, msg: '未知命令' })
-        break
+      case 'utilMSG': {
+        this.emit('utilMSG', message)
+      }
     }
+
+    return {cmd, ts, msg: '未知命令'}
   }
+
   /**
    * 后端完成工作，向客户端发送回调信息
-   * 
+   *
    * @param {message} message
    */
   public async callback(message: message) {
     const cmd = message.cmd
     const ts = message.ts
     const msg = message.msg
-    this._Send({ cmd, ts, msg })
+    this._Send({cmd, ts, msg})
   }
+
   /**
    * 向客户端发送消息
    *
@@ -338,6 +372,7 @@ class WebAPI extends EventEmitter {
     if (this._wsClient.readyState === ws.OPEN) this._wsClient.send(B64XorCipher.encode(Options._.server.netkey || '', JSON.stringify(message)))
   }
 }
+
 // WebSocket消息
 interface message {
   cmd: string
@@ -348,5 +383,6 @@ interface message {
   data?: config | advConfig | optionsInfo | string[] | userData | utilData
   captcha?: string
 }
+
 export default WebAPI
-export { message }
+export {message}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "copy:view": "cp -r docs/view/ docs/index.html build/",
     "copy:view:windows": "xcopy docs\\view\\* build\\view\\ /Y && xcopy docs\\index.html build\\ /Y",
     "clean": "rimraf build && mkdir build && rimraf logs && mkdir logs",
-    "start": "node build/app.js"
+    "start": "node build/app.js",
+    "dev": "npm run build && npm run start"
   },
   "config": {
     "commitizen": {


### PR DESCRIPTION
请求地址 => http(s)://ip:你设置的端口(options.server.port)/api

请求方式 => POST

请求参数 => Header 包含 authorization 值为 options.server.protocol

具体接口和参数与 ws 操作一致，返回内容一致，具体传入和传出参数请参照 [webapi.ts](./blob/master/bilive/webapi.ts)


目前有
```json
{
    "getLog": "获取日志",
    "getConfig": "获取配置",
    "setConfig": "设置配置",
    "getAdvConfig": "获取高级设置",
    "setAdvConfig": "设置高级设置",
    "setNewNetkey": "修改密钥",
    "getInfo": "获取参数描述",
    "getAllUID": "获取uid",
    "getUserData": "获取用户配置",
    "setUserData": "设置用户配置",
    "delUserData": "删除用户",
    "newUserData": "新增用户",
    "getAllUtilID": "获取util ID",
    "getUtilData": "获取utilData",
    "utilMSG": "接收util数据，触发对应util"
}
```

本次提交添加了 .editorconfig 用来配置编辑器，以及新增 dev 用来快速启动测试 `npm run dev`